### PR TITLE
Downgrade solution to .NET 8

### DIFF
--- a/Analyze/Analyze.csproj
+++ b/Analyze/Analyze.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Dto.Tests/Dto.Tests.csproj
+++ b/Dto.Tests/Dto.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <Reference Include="Dto">
-      <HintPath>..\Dto\bin\Debug\net10.0\Dto.dll</HintPath>
+      <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Dto/Dto.csproj
+++ b/Dto/Dto.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Processors.Tests/Processors.Tests.csproj
+++ b/Processors.Tests/Processors.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <Reference Include="Dto">
-      <HintPath>..\Dto\bin\Debug\net10.0\Dto.dll</HintPath>
+      <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Processors/Processors.csproj
+++ b/Processors/Processors.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dto">
-      <HintPath>..\Dto\bin\Debug\net10.0\Dto.dll</HintPath>
+      <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The solution consists of the following projects:
 
 ### Prerequisites
 
-- .NET 10.0 SDK or later
+- .NET 8.0 SDK or later
 - Your favorite IDE (Visual Studio, VS Code, etc.)
 
 ### Building the Solution

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.3.24172.9",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 } 


### PR DESCRIPTION
## Summary
- update build props to target net8.0
- bump global.json to .NET SDK 8.0
- remove framework hardcoding from csproj files
- compute Dto.dll path using TargetFramework from Directory.Build.props
- update README for .NET 8 requirement

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684556d95308832b809f2eef355bd43e