### PR TITLE
Add ActivityLogProcessor tests and switch to .NET 8

### DIFF
--- a/Analyze.Tests/AnalysisServiceTests.cs
+++ b/Analyze.Tests/AnalysisServiceTests.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using Analyze;
+
+namespace Analyze.Tests;
+
+public class AnalysisServiceTests
+{
+    private static string GetTargetFramework()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "../../../../"));
+        var propsPath = Path.Combine(repoRoot, "Directory.Build.props");
+        if (!File.Exists(propsPath))
+        {
+            return "net8.0";
+        }
+
+        var doc = System.Xml.Linq.XDocument.Load(propsPath);
+        var tf = doc.Descendants("TargetFramework").FirstOrDefault();
+        return tf?.Value ?? "net8.0";
+    }
+
+    private static void BuildDto()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "../../../../"));
+        var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = "build Dto/Dto.csproj -c Debug",
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+        process!.WaitForExit();
+    }
+
+    [Fact]
+    public void GetDtoAssemblyTypes_ReturnsUserEventDtoType()
+    {
+        BuildDto();
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<AnalysisService>.Instance;
+        var service = new AnalysisService(logger);
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "../../../../"));
+        var solutionPath = Path.Combine(repoRoot, "UsageAnalyzer.sln");
+        var types = service.GetDtoAssemblyTypes(solutionPath);
+        Assert.Contains(types, t => t.FullName == "Dto.UserEventDto");
+    }
+
+    [Fact]
+    public async Task AnalyzeUsageAsync_FindsPropertyUsage()
+    {
+        BuildDto();
+        using var temp = new TempSolution();
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<AnalysisService>.Instance;
+        var service = new AnalysisService(logger);
+        var results = await service.AnalyzeUsageAsync(temp.SolutionPath, typeof(Dto.UserEventDto), false);
+        var expectedKey = new UsageKey(temp.FilePath, new ClassAndField("User", "UserId"));
+        Assert.True(results.TryGetValue(expectedKey, out var count) && count == 1);
+        Assert.Contains(results, kvp => kvp.Key.Attribute.FieldName == "Email" && kvp.Value == 0);
+    }
+
+    private sealed class TempSolution : IDisposable
+    {
+        public string SolutionDir { get; }
+        public string SolutionPath { get; }
+        public string FilePath { get; }
+
+        public TempSolution()
+        {
+            SolutionDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(SolutionDir);
+            var projectPath = Path.Combine(SolutionDir, "TestProj.csproj");
+            var tf = GetTargetFramework();
+            var dtoDll = Path.Combine(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory!, "../../../../")), "Dto", "bin", "Debug", tf, "Dto.dll");
+            File.WriteAllText(projectPath, @$"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>{tf}</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""Dto"">
+      <HintPath>{dtoDll}</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>");
+            var targetDllPath = Path.Combine(SolutionDir, "Dto", "bin", "Debug", tf, "Dto.dll");
+            Directory.CreateDirectory(Path.GetDirectoryName(targetDllPath)!);
+            File.Copy(dtoDll, targetDllPath, true);
+            FilePath = Path.Combine(SolutionDir, "Program.cs");
+            File.WriteAllText(FilePath, "using Dto; public class P { void M(UserEventDto dto) { var id = dto.User.UserId; } }");
+            SolutionPath = Path.Combine(SolutionDir, "Test.sln");
+            File.WriteAllText(SolutionPath, $"Microsoft Visual Studio Solution File, Format Version 12.00\n# Visual Studio Version 17\nProject(\"{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}\") = \"TestProj\", \"TestProj.csproj\", \"{{{Guid.NewGuid()}}}\"\nEndProject\nGlobal\nEndGlobal");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(SolutionDir, true);
+            }
+            catch { }
+        }
+    }
+}

--- a/Analyze.Tests/Analyze.Tests.csproj
+++ b/Analyze.Tests/Analyze.Tests.csproj
@@ -1,9 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
@@ -16,15 +14,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
     <Using Include="Xunit"/>
   </ItemGroup>
-
   <ItemGroup>
+    <ProjectReference Include="..\Analyze\Analyze.csproj"/>
     <Reference Include="Dto">
       <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
-
 </Project>

--- a/Analyze/AnalysisService.cs
+++ b/Analyze/AnalysisService.cs
@@ -28,8 +28,22 @@ public class AnalysisService(ILogger<AnalysisService> logger)
     private static string GetDtoAssemblyPath(string solutionPath)
     {
         var solutionDir = Path.GetDirectoryName(solutionPath)!;
-        var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", "net10.0", "Dto.dll");
+        var targetFramework = GetTargetFramework(solutionDir);
+        var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", targetFramework, "Dto.dll");
         return dtoAssemblyPath;
+    }
+
+    private static string GetTargetFramework(string solutionDir)
+    {
+        var propsPath = Path.Combine(solutionDir, "Directory.Build.props");
+        if (!File.Exists(propsPath))
+        {
+            return "net8.0";
+        }
+
+        var doc = System.Xml.Linq.XDocument.Load(propsPath);
+        var tfElement = doc.Descendants("TargetFramework").FirstOrDefault();
+        return tfElement?.Value ?? "net8.0";
     }
 
     public async Task<Dictionary<UsageKey, int>> AnalyzeUsageAsync(string solutionPath, Type selectedClass, bool shouldSkipTestProjects)

--- a/Analyze/Analyze.csproj
+++ b/Analyze/Analyze.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/Dto/Dto.csproj
+++ b/Dto/Dto.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Processors.Tests/ActivityLogProcessorTests.cs
+++ b/Processors.Tests/ActivityLogProcessorTests.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+
+namespace Processors.Tests;
+
+public class ActivityLogProcessorTests
+{
+    [Fact]
+    public void Process_ValidJson_WritesFormattedActivityLog()
+    {
+        // Arrange
+        var json =
+            """
+            {
+                "eventId": "12345",
+                "timestamp": "2023-10-01T12:00:00Z",
+                "source": "User Activity System",
+                "message": "User has been imported.",
+                "user": {
+                    "userId": "user123",
+                    "username": "johndoe",
+                    "email": "john.doe@example.com",
+                    "firstName": "John",
+                    "lastName": "Doe",
+                    "dateOfBirth": "1980-01-01",
+                    "gender": "Male",
+                    "phoneNumber": "+1234567890",
+                    "address": {
+                        "street": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "zipCode": "12345",
+                        "country": "USA"
+                    },
+                    "preferences": {
+                        "theme": "dark",
+                        "language": "en",
+                        "notifications": true,
+                        "newsletter": false,
+                        "timezone": "UTC-8"
+                    },
+                    "lastLogin": "2023-09-30T10:00:00Z",
+                    "accountStatus": "active",
+                    "subscriptionPlan": "premium",
+                    "paymentMethod": "credit card",
+                    "lastPaymentDate": "2023-09-15",
+                    "totalOrders": 15,
+                    "favoriteCategories": ["electronics", "books", "clothing"],
+                    "wishlist": ["item1", "item2", "item3"],
+                    "recentSearches": ["laptop", "headphones", "smartphone"],
+                    "cartItems": 3,
+                    "loyaltyPoints": 500,
+                    "referralCode": "REF123",
+                    "socialMedia": {
+                        "facebook": "facebook.com/johndoe",
+                        "twitter": "twitter.com/johndoe",
+                        "instagram": "instagram.com/johndoe"
+                    },
+                    "deviceInfo": {
+                        "deviceType": "mobile",
+                        "os": "iOS",
+                        "browser": "Safari",
+                        "ipAddress": "192.168.1.1"
+                    },
+                    "activityLog": [
+                        {
+                            "action": "login",
+                            "timestamp": "2023-09-30T10:00:00Z"
+                        },
+                        {
+                            "action": "viewProduct",
+                            "productId": "prod123",
+                            "timestamp": "2023-09-30T10:05:00Z"
+                        }
+                    ]
+                }
+            }
+            """;
+        var processor = new ActivityLogProcessor();
+        var output = new StringWriter();
+
+        // Act
+        processor.Process(json, output);
+        var result = output.ToString();
+
+        // Assert
+        Assert.Contains("User Activity Log:", result);
+        Assert.Contains("Action: viewProduct", result);
+        Assert.Contains("Product ID: prod123", result);
+        Assert.Contains("Action: login", result);
+    }
+
+    [Fact]
+    public void Process_EmptyActivityLog_WritesNoDataMessage()
+    {
+        // Arrange
+        var json =
+            """
+            {
+                "eventId": "12345",
+                "timestamp": "2023-10-01T12:00:00Z",
+                "source": "User Activity System",
+                "message": "User has been imported.",
+                "user": {
+                    "userId": "user123",
+                    "username": "johndoe",
+                    "email": "john.doe@example.com",
+                    "firstName": "John",
+                    "lastName": "Doe",
+                    "dateOfBirth": "1980-01-01",
+                    "gender": "Male",
+                    "phoneNumber": "+1234567890",
+                    "address": {
+                        "street": "123 Main St",
+                        "city": "Anytown",
+                        "state": "CA",
+                        "zipCode": "12345",
+                        "country": "USA"
+                    },
+                    "preferences": {
+                        "theme": "dark",
+                        "language": "en",
+                        "notifications": true,
+                        "newsletter": false,
+                        "timezone": "UTC-8"
+                    },
+                    "lastLogin": "2023-09-30T10:00:00Z",
+                    "accountStatus": "active",
+                    "subscriptionPlan": "premium",
+                    "paymentMethod": "credit card",
+                    "lastPaymentDate": "2023-09-15",
+                    "totalOrders": 15,
+                    "favoriteCategories": ["electronics", "books", "clothing"],
+                    "wishlist": ["item1", "item2", "item3"],
+                    "recentSearches": ["laptop", "headphones", "smartphone"],
+                    "cartItems": 3,
+                    "loyaltyPoints": 500,
+                    "referralCode": "REF123",
+                    "socialMedia": {
+                        "facebook": "facebook.com/johndoe",
+                        "twitter": "twitter.com/johndoe",
+                        "instagram": "instagram.com/johndoe"
+                    },
+                    "deviceInfo": {
+                        "deviceType": "mobile",
+                        "os": "iOS",
+                        "browser": "Safari",
+                        "ipAddress": "192.168.1.1"
+                    },
+                    "activityLog": []
+                }
+            }
+            """;
+        var processor = new ActivityLogProcessor();
+        var output = new StringWriter();
+
+        // Act
+        processor.Process(json, output);
+        var result = output.ToString();
+
+        // Assert
+        Assert.Contains("No activity log found.", result);
+    }
+}

--- a/Processors.Tests/Processors.Tests.csproj
+++ b/Processors.Tests/Processors.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <Reference Include="Dto">
-      <HintPath>..\Dto\bin\Debug\net10.0\Dto.dll</HintPath>
+      <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Processors/Processors.csproj
+++ b/Processors/Processors.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dto">
-      <HintPath>..\Dto\bin\Debug\net10.0\Dto.dll</HintPath>
+      <HintPath>..\Dto\bin\Debug\$(TargetFramework)\Dto.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The solution consists of the following projects:
 
 ### Prerequisites
 
-- .NET 10.0 SDK or later
+- .NET 8.0 SDK or later
 - Your favorite IDE (Visual Studio, VS Code, etc.)
 
 ### Building the Solution

--- a/UsageAnalyzer.sln
+++ b/UsageAnalyzer.sln
@@ -20,6 +20,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Processors.Tests", "Process
 		{E67BABBB-6AB9-4EDB-9EAD-57A49939FE89} = {E67BABBB-6AB9-4EDB-9EAD-57A49939FE89}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyze.Tests", "Analyze.Tests\Analyze.Tests.csproj", "{13B452F2-A209-4E6F-B6A1-24434DD3F672}"
+        ProjectSection(ProjectDependencies) = postProject
+                {05BF502A-CCF2-4B60-8E29-7DAED5866A14} = {05BF502A-CCF2-4B60-8E29-7DAED5866A14}
+                {E67BABBB-6AB9-4EDB-9EAD-57A49939FE89} = {E67BABBB-6AB9-4EDB-9EAD-57A49939FE89}
+        EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Analyze", "Analyze\Analyze.csproj", "{05BF502A-CCF2-4B60-8E29-7DAED5866A14}"
 EndProject
 Global
@@ -80,6 +86,18 @@ Global
 		{864F2924-304C-4744-BDE3-E2EB3310AC2F}.Release|x64.Build.0 = Release|Any CPU
 		{864F2924-304C-4744-BDE3-E2EB3310AC2F}.Release|x86.ActiveCfg = Release|Any CPU
 		{864F2924-304C-4744-BDE3-E2EB3310AC2F}.Release|x86.Build.0 = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|x64.Build.0 = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Debug|x86.Build.0 = Debug|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|Any CPU.Build.0 = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|x64.ActiveCfg = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|x64.Build.0 = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|x86.ActiveCfg = Release|Any CPU
+                {13B452F2-A209-4E6F-B6A1-24434DD3F672}.Release|x86.Build.0 = Release|Any CPU
 		{05BF502A-CCF2-4B60-8E29-7DAED5866A14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{05BF502A-CCF2-4B60-8E29-7DAED5866A14}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{05BF502A-CCF2-4B60-8E29-7DAED5866A14}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.3.24172.9",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 } 


### PR DESCRIPTION
## Summary
- switch solution to .NET 8
- update AnalysisService to look up target framework dynamically
- adjust AnalysisServiceTests for new framework detection
- reference built DTO via `$(TargetFramework)`
- include ActivityLogProcessor tests from main

## Testing
- `dotnet test UsageAnalyzer.sln`

------
https://chatgpt.com/codex/tasks/task_e_684552ccc208832bac34d825acc75880