### PR TITLE
Expose analysis service helpers for tests

### DIFF
--- a/Analyze.Tests/AnalysisServiceTests.cs
+++ b/Analyze.Tests/AnalysisServiceTests.cs
@@ -1,7 +1,6 @@
 using Analyze;
 using Dto;
 using Microsoft.Extensions.Logging;
-using System.Reflection;
 
 namespace Analyze.Tests;
 
@@ -31,22 +30,20 @@ public class AnalysisServiceTests
     [Fact]
     public void IsNullable_DetectsNullableTypes()
     {
-        var method = typeof(AnalysisService).GetMethod("IsNullable", BindingFlags.NonPublic | BindingFlags.Static)!;
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(int?) })!);
-        Assert.False((bool)method.Invoke(null, new object[] { typeof(int) })!);
+        Assert.True(AnalysisService.IsNullable(typeof(int?)));
+        Assert.False(AnalysisService.IsNullable(typeof(int)));
     }
 
     [Fact]
     public void IsPrimitiveOrArrayOfPrimitives_ReturnsExpected()
     {
-        var method = typeof(AnalysisService).GetMethod("IsPrimitiveOrArrayOfPrimitives", BindingFlags.NonPublic | BindingFlags.Static)!;
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(int) })!);
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(string) })!);
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(decimal) })!);
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(DateTime) })!);
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(string[]) })!);
-        Assert.True((bool)method.Invoke(null, new object[] { typeof(List<int>) })!);
-        Assert.False((bool)method.Invoke(null, new object[] { typeof(DeviceInfo) })!);
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(int)));
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(string)));
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(decimal)));
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(DateTime)));
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(string[])));
+        Assert.True(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(List<int>)));
+        Assert.False(AnalysisService.IsPrimitiveOrArrayOfPrimitives(typeof(DeviceInfo)));
     }
 
     [Fact]
@@ -63,12 +60,11 @@ public class AnalysisServiceTests
     [Fact]
     public void GetTargetFramework_ReturnsNet80WhenFileMissing()
     {
-        var method = typeof(AnalysisService).GetMethod("GetTargetFramework", BindingFlags.NonPublic | BindingFlags.Static)!;
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(temp);
         try
         {
-            var framework = (string)method.Invoke(null, new object[] { temp })!;
+            var framework = AnalysisService.GetTargetFramework(temp);
             Assert.Equal("net8.0", framework);
         }
         finally
@@ -80,7 +76,6 @@ public class AnalysisServiceTests
     [Fact]
     public void GetTargetFramework_ReadsValueFromProps()
     {
-        var method = typeof(AnalysisService).GetMethod("GetTargetFramework", BindingFlags.NonPublic | BindingFlags.Static)!;
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(temp);
         File.WriteAllText(Path.Combine(temp, "Directory.Build.props"), """
@@ -92,7 +87,7 @@ public class AnalysisServiceTests
 """);
         try
         {
-            var framework = (string)method.Invoke(null, new object[] { temp })!;
+            var framework = AnalysisService.GetTargetFramework(temp);
             Assert.Equal("net7.0", framework);
         }
         finally

--- a/Analyze/AnalysisService.cs
+++ b/Analyze/AnalysisService.cs
@@ -34,7 +34,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
         return dtoAssemblyPath;
     }
 
-    private static string GetTargetFramework(string solutionDir)
+    public static string GetTargetFramework(string solutionDir)
     {
         var propsPath = Path.Combine(solutionDir, "Directory.Build.props");
         if (!File.Exists(propsPath))
@@ -274,7 +274,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
         return properties;
     }
 
-    private static bool IsPrimitiveOrArrayOfPrimitives(Type type)
+    public static bool IsPrimitiveOrArrayOfPrimitives(Type type)
     {
         if (type.IsPrimitive || type == typeof(string) || type == typeof(decimal) || type == typeof(DateTime))
         {
@@ -306,7 +306,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
         return type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
     }
     
-    private static bool IsNullable(Type type)
+    public static bool IsNullable(Type type)
     {
         return Nullable.GetUnderlyingType(type) != null;
     }


### PR DESCRIPTION
## Summary
- expose AnalysisService helper methods as public so they can be called directly
- remove reflection from AnalysisService unit tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684567a7f084832bb67c36fc67462268