### PR TITLE
Make DTO path external

### DIFF
--- a/Analyze.Tests/AnalysisServiceTests.cs
+++ b/Analyze.Tests/AnalysisServiceTests.cs
@@ -1,6 +1,7 @@
 using Analyze;
 using Dto;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace Analyze.Tests;
 
@@ -23,7 +24,11 @@ public class AnalysisServiceTests
     public void GetDtoAssemblyTypes_ReturnsDtoTypes()
     {
         var service = CreateService();
-        var types = service.GetDtoAssemblyTypes(GetSolutionPath());
+        var solutionPath = GetSolutionPath();
+        var solutionDir = Path.GetDirectoryName(solutionPath)!;
+        var tf = AnalysisService.GetTargetFramework(solutionDir);
+        var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", tf, "Dto.dll");
+        var types = service.GetDtoAssemblyTypes(dtoAssemblyPath);
         Assert.Contains(types, t => t.Name == nameof(UserEventDto));
     }
 
@@ -100,10 +105,15 @@ public class AnalysisServiceTests
     public async Task AnalyzeUsageAsync_ReturnsUsageCounts()
     {
         var service = CreateService();
+        var solutionPath = GetSolutionPath();
+        var solutionDir = Path.GetDirectoryName(solutionPath)!;
+        var tf = AnalysisService.GetTargetFramework(solutionDir);
+        var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", tf, "Dto.dll");
         var result = await service.AnalyzeUsageAsync(
-            GetSolutionPath(),
+            solutionPath,
             typeof(UserEventDto),
-            true);
+            true,
+            dtoAssemblyPath);
 
         var aggregated = result
             .GroupBy(r => r.Key.Attribute)

--- a/Analyze/Program.cs
+++ b/Analyze/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
+using System.IO;
 
 namespace Analyze;
 
@@ -28,7 +29,10 @@ public class Program
             var solutionPath = consoleUi.FindSolutionFile();
 
             // Get all DTO classes
-            var dtoClasses = analysisService.GetDtoAssemblyTypes(solutionPath).ToList();
+            var solutionDir = Path.GetDirectoryName(solutionPath)!;
+            var tf = AnalysisService.GetTargetFramework(solutionDir);
+            var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", tf, "Dto.dll");
+            var dtoClasses = analysisService.GetDtoAssemblyTypes(dtoAssemblyPath).ToList();
             if (!dtoClasses.Any())
             {
                 AnsiConsole.MarkupLine("[red]No DTO classes found in the Dto project.[/]");
@@ -51,7 +55,7 @@ public class Program
 
             // Analyze usage
             var propertyUsage = await analysisService
-                .AnalyzeUsageAsync(solutionPath, selectedClass, skipTestProjects);
+                .AnalyzeUsageAsync(solutionPath, selectedClass, skipTestProjects, dtoAssemblyPath);
 
             // Display results
             consoleUi.DisplayResults(propertyUsage, selectedClass, propertyUsageFormat);


### PR DESCRIPTION
## Summary
- remove `GetDtoAssemblyPath` from `AnalysisService`
- compute DTO assembly path in console app and tests
- update `GetDtoAssemblyTypes` to take the DTO path directly

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685e92318734832bb8ae4e2f55c63970