### PR TITLE
Remove dto path argument from usage analyzer

### DIFF
--- a/Analyze.Tests/AnalysisServiceTests.cs
+++ b/Analyze.Tests/AnalysisServiceTests.cs
@@ -107,13 +107,10 @@ public class AnalysisServiceTests
         var service = CreateService();
         var solutionPath = GetSolutionPath();
         var solutionDir = Path.GetDirectoryName(solutionPath)!;
-        var tf = AnalysisService.GetTargetFramework(solutionDir);
-        var dtoAssemblyPath = Path.Combine(solutionDir, "Dto", "bin", "Debug", tf, "Dto.dll");
         var result = await service.AnalyzeUsageAsync(
             solutionPath,
             typeof(UserEventDto),
-            true,
-            dtoAssemblyPath);
+            true);
 
         var aggregated = result
             .GroupBy(r => r.Key.Attribute)

--- a/Analyze/Program.cs
+++ b/Analyze/Program.cs
@@ -55,7 +55,7 @@ public class Program
 
             // Analyze usage
             var propertyUsage = await analysisService
-                .AnalyzeUsageAsync(solutionPath, selectedClass, skipTestProjects, dtoAssemblyPath);
+                .AnalyzeUsageAsync(solutionPath, selectedClass, skipTestProjects);
 
             // Display results
             consoleUi.DisplayResults(propertyUsage, selectedClass, propertyUsageFormat);

--- a/DtoUsageAnalyzer/AnalysisService.cs
+++ b/DtoUsageAnalyzer/AnalysisService.cs
@@ -42,8 +42,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
     public async Task<Dictionary<UsageKey, int>> AnalyzeUsageAsync(
         string solutionPath,
         Type selectedClass,
-        bool shouldSkipTestProjects,
-        string dtoAssemblyPath)
+        bool shouldSkipTestProjects)
     {
         logger.LogDebug("Starting analysis for class: {SelectedClassFullName}", selectedClass.FullName);
         var propertyUsage = new Dictionary<UsageKey, int>();
@@ -73,7 +72,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
                 continue;
             }
 
-            var compilation = await SetupProjectCompilation(project, dtoAssemblyPath);
+            var compilation = await SetupProjectCompilation(project, selectedClass.Assembly.Location);
             if (compilation == null)
             {
                 continue;
@@ -99,7 +98,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
         return propertyUsage;
     }
 
-    private async Task<Compilation?> SetupProjectCompilation(Project project, string dtoAssemblyPath)
+    private async Task<Compilation?> SetupProjectCompilation(Project project, string assemblyPath)
     {
         var coreAssemblyPath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         return (await project.GetCompilationAsync())?
@@ -111,7 +110,7 @@ public class AnalysisService(ILogger<AnalysisService> logger)
                 MetadataReference.CreateFromFile(typeof(List<>).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),
-                MetadataReference.CreateFromFile(dtoAssemblyPath)
+                MetadataReference.CreateFromFile(assemblyPath)
             );
     }
 


### PR DESCRIPTION
## Summary
- simplify `AnalyzeUsageAsync` so the DTO assembly path is inferred from the selected class
- update Program and tests to use the new signature

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685e96edacd0832baf8ef1b041685340